### PR TITLE
Add option to output code

### DIFF
--- a/cce/main.py
+++ b/cce/main.py
@@ -105,7 +105,11 @@ def main():
                         '--file',
                         help='The file to extract from',
                         required=True)
-
+    parser.add_argument('-o',
+                        '--output_code',
+                        help='Whether to write the code content to stdout',
+                        action='store_true'
+                        )
     args = parser.parse_args()
 
     contents = extract_from_file(args.file)
@@ -123,6 +127,8 @@ def main():
     if errors > 0:
         print(s)
         sys.exit(errors)
+    elif args.output_code:
+        print(contents)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a commandline option to write the extracted code block to stdout. Note that when errors are found, the stdout is 'polluted' with an error message as well, maybe it would be neater to write that to stderr only.

Also, with this code I found out that no code is extracted when I run the tool, so there's probably something wrong with the regex.